### PR TITLE
Remove byproduct from cddaxp_survrbelt

### DIFF
--- a/CDDAXP_Recipes.json
+++ b/CDDAXP_Recipes.json
@@ -463,7 +463,6 @@
 	{
 		"type" : "recipe",
 		"result": "cddaxp_survrbelt",
-		"byproducts": [ [ "leather", 6 ] ],
 		"category": "CC_ARMOR",
 		"subcategory": "CSC_ARMOR_OTHER",
 		"skill_used": "fabrication",


### PR DESCRIPTION
Latest experimental of CDDA shows error with cddaxp_survrbelt : `Can't be reversible and have byproduct`

So basically I removed byproducts from the recipe.